### PR TITLE
Add ability to respond to events from Vera hub

### DIFF
--- a/pyvera/__init__.py
+++ b/pyvera/__init__.py
@@ -5,12 +5,25 @@ import time
 
 import requests
 
+from .subscribe import SubscriptionRegistry
+
 """
 Vera Controller Python API
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 This lib is designed to simplify communication with Vera Z-Wave controllers
 """
+
+_VERA_CONTROLLER = None
+
+def init_controller(url):
+    global _VERA_CONTROLLER
+    created = False
+    if _VERA_CONTROLLER is None:
+        _VERA_CONTROLLER = VeraController(url)
+        created = True
+        _VERA_CONTROLLER.start()
+    return [_VERA_CONTROLLER, created]
 
 class VeraController(object):
 
@@ -24,6 +37,7 @@ class VeraController(object):
         self.model = None
         self.serial_number = None
         self.device_services_map = None
+        self.subscription_registry = SubscriptionRegistry()
 
     def get_simple_devices_info(self):
 
@@ -162,6 +176,18 @@ class VeraController(object):
                 break
                 item['value'] = value
 
+
+    def start(self):
+        self.subscription_registry.start()
+
+    def stop(self):
+        self.subscription_registry.stop()
+
+    def register(self, device):
+        self.subscription_registry.register(device)
+
+    def on(self, *params):
+        self.subscription_registry.on(*params)
 
 class VeraDevice(object):
 

--- a/pyvera/subscribe.py
+++ b/pyvera/subscribe.py
@@ -2,61 +2,14 @@
 import collections
 import functools
 import logging
-import sched
-import socket
 import time
 import threading
-
-from cgi import parse_header, parse_multipart
-from xml.etree import cElementTree
-
-try:
-    import BaseHTTPServer
-    from urlparse import parse_qs
-except ImportError:
-    import http.server as BaseHTTPServer
-    from urllib.parse import parse_qs
-
 import requests
 
+SUBSCRIPTION_RETRY = 60
+# Time to wait for event in seconds
+
 LOG = logging.getLogger(__name__)
-SUCCESS = '<html><body><h1>200 OK</h1></body></html>'
-PORT = 8990
-
-
-class RequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
-
-    def do_POST(self):
-        outer = self.server.outer
-        # CITATION: http://stackoverflow.com/questions/4233218/python-basehttprequesthandler-post-variables
-        ctype, pdict = parse_header(self.headers['content-type'])
-        if ctype == 'multipart/form-data':
-            postvars = parse_multipart(self.rfile, pdict)
-        elif ctype == 'application/x-www-form-urlencoded':
-            length = int(self.headers['content-length'])
-            postvars = parse_qs(
-                    self.rfile.read(length),
-                    keep_blank_values=1)
-        else:
-            postvars = {}
-
-        postvars = {k.decode('utf8'): [v.decode('UTF8') for v in l] for k, l in postvars.items()}
-        devices = [outer._devices.get(int(id)) for id in postvars.get('device_id', [])]
-
-        outer._event(devices)
-
-        # Tell the browser everything is okay and that there is
-        # HTML to display.
-        self.send_response(200)
-        self.send_header('Content-Type', 'text/html')
-        self.send_header('Content-Length', len(SUCCESS))
-        self.send_header('Connection', 'close')
-        self.end_headers()
-        self.wfile.write(SUCCESS.encode("UTF-8"))
-
-    def log_message(self, format, *args):
-      LOG.info(format, *args)
-
 
 class SubscriptionRegistry(object):
     """Class for subscribing to wemo events."""
@@ -65,9 +18,7 @@ class SubscriptionRegistry(object):
         self._devices = {}
         self._callbacks = collections.defaultdict(list)
         self._exiting = False
-
-        self._http_thread = None
-        self._httpd = None
+        self._poll_thread = None
 
     def register(self, device):
         if not device:
@@ -92,27 +43,33 @@ class SubscriptionRegistry(object):
                 for callback in callbacks:
                     callback(device)
 
-
+    def join(self):
+        self._poll_thread.join()
 
     def on(self, device, callback):
         self._callbacks[device].append((callback))
 
     def start(self):
-        self._http_thread = threading.Thread(target=self._run_http_server,
-                                             name='Vera HTTP Thread')
-        self._http_thread.deamon = True
-        self._http_thread.start()
+        self._poll_thread = threading.Thread(target=self._run_poll_server,
+                                             name='Vera Poll Thread')
+        self._poll_thread.deamon = True
+        self._poll_thread.start()
 
     def stop(self):
-        self._httpd.shutdown()
+        self._exiting = True
 
-    def join(self):
-        self._http_thread.join()
+    def _run_poll_server(self):
+        from pyvera import get_controller
+        controller = get_controller()
+        timestamp = controller.get_initial_timestamp()
+        while not self._exiting:
+            try:
+                device_ids, timestamp = controller.get_changed_devices(timestamp)
+                devices = [self._devices.get(int(id)) for id in device_ids]
+                self._event(devices)
+            except requests.RequestException:
+                LOG.info("Could not contact Vera - will retry in %ss", SUBSCRIPTION_RETRY)
+                time.sleep(SUBSCRIPTION_RETRY)
 
-    def _run_http_server(self):
-        self._httpd = BaseHTTPServer.HTTPServer(('', PORT), RequestHandler)
-        self._httpd.allow_reuse_address = True
-        self._httpd.outer = self
-        LOG.info("Vera listening on port %d", PORT)
-        self._httpd.serve_forever()
+        LOG.info("Shutdown Vera Poll Thread")
 

--- a/pyvera/subscribe.py
+++ b/pyvera/subscribe.py
@@ -1,0 +1,118 @@
+"""Module to listen for vera events."""
+import collections
+import functools
+import logging
+import sched
+import socket
+import time
+import threading
+
+from cgi import parse_header, parse_multipart
+from xml.etree import cElementTree
+
+try:
+    import BaseHTTPServer
+    from urlparse import parse_qs
+except ImportError:
+    import http.server as BaseHTTPServer
+    from urllib.parse import parse_qs
+
+import requests
+
+LOG = logging.getLogger(__name__)
+SUCCESS = '<html><body><h1>200 OK</h1></body></html>'
+PORT = 8990
+
+
+class RequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
+
+    def do_POST(self):
+        outer = self.server.outer
+        # CITATION: http://stackoverflow.com/questions/4233218/python-basehttprequesthandler-post-variables
+        ctype, pdict = parse_header(self.headers['content-type'])
+        if ctype == 'multipart/form-data':
+            postvars = parse_multipart(self.rfile, pdict)
+        elif ctype == 'application/x-www-form-urlencoded':
+            length = int(self.headers['content-length'])
+            postvars = parse_qs(
+                    self.rfile.read(length),
+                    keep_blank_values=1)
+        else:
+            postvars = {}
+
+        postvars = {k.decode('utf8'): [v.decode('UTF8') for v in l] for k, l in postvars.items()}
+        devices = [outer._devices.get(int(id)) for id in postvars.get('device_id', [])]
+
+        outer._event(devices)
+
+        # Tell the browser everything is okay and that there is
+        # HTML to display.
+        self.send_response(200)
+        self.send_header('Content-Type', 'text/html')
+        self.send_header('Content-Length', len(SUCCESS))
+        self.send_header('Connection', 'close')
+        self.end_headers()
+        self.wfile.write(SUCCESS.encode("UTF-8"))
+
+    def log_message(self, format, *args):
+      LOG.info(format, *args)
+
+
+class SubscriptionRegistry(object):
+    """Class for subscribing to wemo events."""
+
+    def __init__(self):
+        self._devices = {}
+        self._callbacks = collections.defaultdict(list)
+        self._exiting = False
+
+        self._http_thread = None
+        self._httpd = None
+
+    def register(self, device):
+        if not device:
+            LOG.error("Received an invalid device: %r", device)
+            return
+
+        LOG.info("Subscribing to events for %s", device.name)
+        # Provide a function to register a callback when the device changes
+        # state
+        device.register_listener = functools.partial(self.on, device, None)
+        self._devices[device.vera_device_id] = device
+
+    def _event(self, devices):
+        LOG.info("Got vera event for devices %s", [d.name for d in devices])
+        # if not devices specified - callback everything
+        if devices:
+            for device in devices:
+                for callback in self._callbacks.get(device, ()):
+                    callback(device)
+        else:
+            for device, callbacks in self._callbacks.items():
+                for callback in callbacks:
+                    callback(device)
+
+
+
+    def on(self, device, callback):
+        self._callbacks[device].append((callback))
+
+    def start(self):
+        self._http_thread = threading.Thread(target=self._run_http_server,
+                                             name='Vera HTTP Thread')
+        self._http_thread.deamon = True
+        self._http_thread.start()
+
+    def stop(self):
+        self._httpd.shutdown()
+
+    def join(self):
+        self._http_thread.join()
+
+    def _run_http_server(self):
+        self._httpd = BaseHTTPServer.HTTPServer(('', PORT), RequestHandler)
+        self._httpd.allow_reuse_address = True
+        self._httpd.outer = self
+        LOG.info("Vera listening on port %d", PORT)
+        self._httpd.serve_forever()
+


### PR DESCRIPTION
This PR, based on the code from pywemo adds an ability to respond to events from a Vera controller, which is faster than waiting for HA to poll Vera.

This code sets up a web endpoint that will respond to a POST, and re-uses the subscription logic from pywemo to notify HA.

To use this in Vera you need to create a scene that depends on the events you want to react to, and then add the following `custom lua` code to the scene. It can specify the vera_id of the device that is to be updated, multiple device ids, or no id (which will update all the Vera devices known to HA. 

```
local http = require("socket.http")
http.TIMEOUT = 5
result, status = http.request("http://000.000.000:8990/update", "device_id=29")
```

You need to update with the address of your HA server.